### PR TITLE
Fix incorrect slash in Path API call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.19'
+def runeLiteVersion = '1.6.27'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/flipper/helpers/TradePersister.java
+++ b/src/main/java/com/flipper/helpers/TradePersister.java
@@ -74,7 +74,7 @@ public class TradePersister {
     }
 
     private static String getFileContent(String filename) throws IOException {
-        Path filePath = Paths.get(directory + "\\" + filename);
+        Path filePath = Paths.get(directory + "/" + filename);
         byte[] fileBytes = Files.readAllBytes(filePath);
         return new String(fileBytes);
     }


### PR DESCRIPTION
Noticed Flipper hasn't been loading correctly, and not showing up, for the past few weeks. Looks like an IOException is getting thrown since plugin init can't find one of the user data jsons, because this slash doesn't match what the API expects.

Updated build.gradle file to get it to load on my machine, not sure if that's correct or not.