### PR TITLE
Feature/add tax

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.11'
+def runeLiteVersion = '1.8.16'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.16'
+def runeLiteVersion = '1.10.7'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/flipper/models/Alch.java
+++ b/src/main/java/com/flipper/models/Alch.java
@@ -15,6 +15,7 @@ public class Alch {
     public UUID userId;
     public UUID buyId;
     public int itemId;
+    String itemName;
     public int quantity;
     public int buyPrice;
     public int natureRunePrice;
@@ -24,21 +25,18 @@ public class Alch {
 
     public Alch() {};
 
-    public Alch(Transaction transaction, ItemManager itemManager) {
-        ItemComposition itemComposition = itemManager.getItemComposition(transaction.getItemId());
+    public Alch(Transaction transaction, int haPrice, int natPrice) {
         this.buyId = transaction.getId();
         this.itemId = transaction.getItemId();
+        this.itemName = transaction.getItemName();
         this.quantity = transaction.getQuantity();
         this.buyPrice = transaction.getPricePer();
-        this.natureRunePrice = itemManager.getItemPriceWithSource(
-            UiUtilities.NATURE_RUNE_ID,
-            true
-        );
-        this.alchPrice = itemComposition.getHaPrice();
+        this.natureRunePrice = natPrice;
+        this.alchPrice = haPrice;
     }
 
-    public String describeAlch(String itemName) {
-        return String.valueOf(quantity) + " " + itemName + "(s)";
+    public String describeAlch() {
+        return String.valueOf(quantity) + " " + this.itemName + "(s)";
     }
 
     public int getTotalProfit() {

--- a/src/main/java/com/flipper/models/Flip.java
+++ b/src/main/java/com/flipper/models/Flip.java
@@ -10,6 +10,8 @@ import lombok.Data;
  */
 @Data
 public class Flip {
+    public static final double TAX_RATE = 0.01;
+
     public UUID id;
     public UUID userId;
     public UUID buyId;
@@ -53,6 +55,15 @@ public class Flip {
      * @return profit of flip
      */
     public int getTotalProfit() {
-        return (sellPrice - buyPrice) * quantity;
+        return (sellPrice - buyPrice - getTax()) * quantity;
+    }
+
+    /**
+     * The GE floors tax per item.
+     *
+     * @return tax per item of flip
+     */
+    public int getTax() {
+        return (int) Math.floor((double)this.sellPrice * TAX_RATE);
     }
 }

--- a/src/main/java/com/flipper/models/Flip.java
+++ b/src/main/java/com/flipper/models/Flip.java
@@ -68,4 +68,13 @@ public class Flip {
     public int getTax() {
         return (int) Math.floor((double)this.sellPrice * TAX_RATE);
     }
+
+    /**
+     * Gets the total tax of the sale
+     *
+     * @return total tax of sale
+     */
+    public int getTotalTax() {
+        return getTax() * quantity;
+    }
 }

--- a/src/main/java/com/flipper/models/Flip.java
+++ b/src/main/java/com/flipper/models/Flip.java
@@ -17,6 +17,7 @@ public class Flip {
     public UUID buyId;
     public UUID sellId;
     public int itemId;
+    String itemName;
     public int quantity;
     public int buyPrice;
     public int sellPrice;
@@ -29,6 +30,7 @@ public class Flip {
         this.buyId = buy.id;
         this.sellId = sell.id;
         this.itemId = sell.getItemId();
+        this.itemName = sell.getItemName();
         this.quantity = sell.getQuantity(); 
         this.buyPrice = buy.getPricePer();
         this.sellPrice = sell.getPricePer();
@@ -45,8 +47,8 @@ public class Flip {
         return quantity == 1 && buyPrice >= sellPrice;
     }
 
-    public String describeFlip(String itemName) {
-        return String.valueOf(quantity) + " " + itemName + "(s)";
+    public String describeFlip() {
+        return String.valueOf(quantity) + " " + this.itemName + "(s)";
     }
 
     /**

--- a/src/main/java/com/flipper/models/Transaction.java
+++ b/src/main/java/com/flipper/models/Transaction.java
@@ -13,6 +13,8 @@ import com.flipper.helpers.GrandExchange;
  */
 @Data
 public class Transaction {
+    public static final double TAX_RATE = 0.01;
+
     public final UUID id;
     private int quantity;
     private int totalQuantity;
@@ -93,5 +95,23 @@ public class Transaction {
 
     public boolean isFilled() {
         return quantity == totalQuantity;
+    }
+
+    /**
+     * The GE floors tax per item.
+     *
+     * @return tax per item of flip
+     */
+    public int getTax() {
+        return (int) Math.floor((double)this.pricePer * TAX_RATE);
+    }
+
+    /**
+     * Gets the total tax of the sale
+     *
+     * @return total tax of sale
+     */
+    public int getTotalTax() {
+        return getTax() * quantity;
     }
 }

--- a/src/main/java/com/flipper/views/alchs/AlchPanel.java
+++ b/src/main/java/com/flipper/views/alchs/AlchPanel.java
@@ -37,10 +37,9 @@ public class AlchPanel extends JPanel {
 
     public AlchPanel(Alch alch, ItemManager itemManager, Consumer<UUID> removeAlchConsumer, boolean isPrompt) {
         this.alch = alch;
-        ItemComposition itemComp = itemManager.getItemComposition(alch.getItemId());
 
         DeleteButton deleteAlchButton = new DeleteButton((ActionEvent action) -> {
-            String describedAlch = alch.describeAlch(itemComp.getName());
+            String describedAlch = alch.describeAlch();
             int input = isPrompt 
                 ? JOptionPane.showConfirmDialog(
                     null,
@@ -59,7 +58,7 @@ public class AlchPanel extends JPanel {
         container.add(new ItemHeader(
             alch.getItemId(),
             0,
-            itemComp.getName(),
+            alch.getItemName(),
             itemManager,
             false,
             deleteAlchButton

--- a/src/main/java/com/flipper/views/flips/FlipPanel.java
+++ b/src/main/java/com/flipper/views/flips/FlipPanel.java
@@ -26,7 +26,7 @@ import net.runelite.client.game.ItemManager;
 public class FlipPanel extends JPanel {
     private Flip flip;
 
-    private static int LABEL_COUNT = 6;
+    private static int LABEL_COUNT = 7;
 
     private JPanel container = new JPanel();
     private JPanel itemInfo = new JPanel(new BorderLayout());
@@ -40,10 +40,9 @@ public class FlipPanel extends JPanel {
         boolean isPrompt
     ) {
         this.flip = flip;
-        ItemComposition itemComp = itemManager.getItemComposition(flip.getItemId());
 
         DeleteButton deleteFlipButton = new DeleteButton((ActionEvent action) -> {
-            String describedBuy = flip.describeFlip(itemComp.getName());
+            String describedBuy = flip.describeFlip();
             int input = isPrompt
                 ? JOptionPane.showConfirmDialog(null, "Delete flip of " + describedBuy + "?")
                 : 0;
@@ -56,7 +55,7 @@ public class FlipPanel extends JPanel {
         this.setLayout(new BorderLayout());
         container.setLayout(new BorderLayout());
         container.setBackground(ColorScheme.DARK_GRAY_COLOR);
-        container.add(new ItemHeader(flip.getItemId(), 0, itemComp.getName(), itemManager, false, deleteFlipButton), BorderLayout.NORTH);
+        container.add(new ItemHeader(flip.getItemId(), 0, flip.getItemName(), itemManager, false, deleteFlipButton), BorderLayout.NORTH);
         constructItemInfo();
         this.setBorder(new EmptyBorder(0, 5, 3, 5));
 

--- a/src/main/java/com/flipper/views/flips/FlipPanel.java
+++ b/src/main/java/com/flipper/views/flips/FlipPanel.java
@@ -26,7 +26,7 @@ import net.runelite.client.game.ItemManager;
 public class FlipPanel extends JPanel {
     private Flip flip;
 
-    private static int LABEL_COUNT = 7;
+    private static int LABEL_COUNT = 8;
 
     private JPanel container = new JPanel();
     private JPanel itemInfo = new JPanel(new BorderLayout());
@@ -87,19 +87,21 @@ public class FlipPanel extends JPanel {
         leftInfoTextPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
 
         JLabel amountFlippedLabel = newLeftLabel("Amount Flipped:");
-        JLabel profitEachLabel = newLeftLabel("Profit Per:");
-        JLabel totalProfitLabel = newLeftLabel("Total Profit:");
         JLabel buyPrice = newLeftLabel("Buy Price:");
         JLabel sellPrice = newLeftLabel("Sell Price:");
-        JLabel tax = newLeftLabel("Tax:");
+        JLabel tax = newLeftLabel("Tax Per:");
+        JLabel totalTax = newLeftLabel("Total Tax:");
+        JLabel profitEachLabel = newLeftLabel("Profit Per:");
+        JLabel totalProfitLabel = newLeftLabel("Total Profit:");
         JLabel flipCreatedAt = newLeftLabel("Date:");
 
         addLeftLabel(amountFlippedLabel);
-        addLeftLabel(profitEachLabel);
-        addLeftLabel(totalProfitLabel);
         addLeftLabel(buyPrice);
         addLeftLabel(sellPrice);
         addLeftLabel(tax);
+        addLeftLabel(totalTax);
+        addLeftLabel(profitEachLabel);
+        addLeftLabel(totalProfitLabel);
         addLeftLabel(flipCreatedAt);
 
         leftInfoTextPanel.setBorder(new EmptyBorder(2, 5, 2, 10));
@@ -129,9 +131,14 @@ public class FlipPanel extends JPanel {
         String amountFlippedText = Integer.toString(this.flip.getQuantity());
         String totalProfitText = Integer.toString(totalProfit);
         String taxEachText = Integer.toString(tax);
+        String totalTaxText = Integer.toString(flip.getTotalTax());
         String profitEachText = Integer.toString(profitEach);
 
         JLabel amountFlippedLabel = newRightLabel(Numbers.numberWithCommas(amountFlippedText), ColorScheme.GRAND_EXCHANGE_ALCH);
+        JLabel taxPerItem = newRightLabel(Numbers.numberWithCommas(taxEachText), ColorScheme.PROGRESS_ERROR_COLOR);
+        JLabel totalTax = newRightLabel(Numbers.numberWithCommas(totalTaxText), ColorScheme.PROGRESS_ERROR_COLOR);
+        JLabel buyPrice = newRightLabel(Numbers.numberWithCommas(flip.getBuyPrice()),  ColorScheme.GRAND_EXCHANGE_ALCH);
+        JLabel sellPrice = newRightLabel(Numbers.numberWithCommas(flip.getSellPrice()),  ColorScheme.GRAND_EXCHANGE_ALCH);
 
         Color profitEachColor = profitEach > 0 ? ColorScheme.GRAND_EXCHANGE_ALCH : ColorScheme.PROGRESS_ERROR_COLOR;
         JLabel profitEachLabel = newRightLabel(Numbers.numberWithCommas(profitEachText), profitEachColor);
@@ -139,18 +146,16 @@ public class FlipPanel extends JPanel {
         Color profitColor = flip.getTotalProfit() > 0 ? ColorScheme.GRAND_EXCHANGE_ALCH
                 : ColorScheme.PROGRESS_ERROR_COLOR;
         JLabel totalProfitLabel = newRightLabel(Numbers.numberWithCommas(totalProfitText), profitColor);
-        JLabel taxPerItem = newRightLabel(Numbers.numberWithCommas(taxEachText), ColorScheme.LIGHT_GRAY_COLOR);
 
-        JLabel buyPrice = newRightLabel(Numbers.numberWithCommas(flip.getBuyPrice()),  ColorScheme.GRAND_EXCHANGE_ALCH);
-        JLabel sellPrice = newRightLabel(Numbers.numberWithCommas(flip.getSellPrice()),  ColorScheme.GRAND_EXCHANGE_ALCH);
         JLabel flipCreatedAt = newRightLabel(Timestamps.format(flip.getCreatedAt()),  ColorScheme.GRAND_EXCHANGE_ALCH);
 
         addRightLabel(amountFlippedLabel);
-        addRightLabel(profitEachLabel);
-        addRightLabel(totalProfitLabel);
         addRightLabel(buyPrice);
         addRightLabel(sellPrice);
         addRightLabel(taxPerItem);
+        addRightLabel(totalTax);
+        addRightLabel(profitEachLabel);
+        addRightLabel(totalProfitLabel);
         addRightLabel(flipCreatedAt);
 
         rightValuesPanel.setBorder(new EmptyBorder(2, 5, 2, 10));

--- a/src/main/java/com/flipper/views/flips/FlipPanel.java
+++ b/src/main/java/com/flipper/views/flips/FlipPanel.java
@@ -92,6 +92,7 @@ public class FlipPanel extends JPanel {
         JLabel totalProfitLabel = newLeftLabel("Total Profit:");
         JLabel buyPrice = newLeftLabel("Buy Price:");
         JLabel sellPrice = newLeftLabel("Sell Price:");
+        JLabel tax = newLeftLabel("Tax:");
         JLabel flipCreatedAt = newLeftLabel("Date:");
 
         addLeftLabel(amountFlippedLabel);
@@ -99,6 +100,7 @@ public class FlipPanel extends JPanel {
         addLeftLabel(totalProfitLabel);
         addLeftLabel(buyPrice);
         addLeftLabel(sellPrice);
+        addLeftLabel(tax);
         addLeftLabel(flipCreatedAt);
 
         leftInfoTextPanel.setBorder(new EmptyBorder(2, 5, 2, 10));
@@ -120,12 +122,14 @@ public class FlipPanel extends JPanel {
         rightValuesPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
 
         int totalProfit = flip.getTotalProfit();
+        int tax = flip.getTax();
 
         int quantity = this.flip.getQuantity();
         int profitEach = quantity != 0 ? totalProfit / quantity : 0;
 
         String amountFlippedText = Integer.toString(this.flip.getQuantity());
         String totalProfitText = Integer.toString(totalProfit);
+        String taxEachText = Integer.toString(tax);
         String profitEachText = Integer.toString(profitEach);
 
         JLabel amountFlippedLabel = newRightLabel(Numbers.numberWithCommas(amountFlippedText), ColorScheme.GRAND_EXCHANGE_ALCH);
@@ -136,6 +140,7 @@ public class FlipPanel extends JPanel {
         Color profitColor = flip.getTotalProfit() > 0 ? ColorScheme.GRAND_EXCHANGE_ALCH
                 : ColorScheme.PROGRESS_ERROR_COLOR;
         JLabel totalProfitLabel = newRightLabel(Numbers.numberWithCommas(totalProfitText), profitColor);
+        JLabel taxPerItem = newRightLabel(Numbers.numberWithCommas(taxEachText), ColorScheme.LIGHT_GRAY_COLOR);
 
         JLabel buyPrice = newRightLabel(Numbers.numberWithCommas(flip.getBuyPrice()),  ColorScheme.GRAND_EXCHANGE_ALCH);
         JLabel sellPrice = newRightLabel(Numbers.numberWithCommas(flip.getSellPrice()),  ColorScheme.GRAND_EXCHANGE_ALCH);
@@ -146,6 +151,7 @@ public class FlipPanel extends JPanel {
         addRightLabel(totalProfitLabel);
         addRightLabel(buyPrice);
         addRightLabel(sellPrice);
+        addRightLabel(taxPerItem);
         addRightLabel(flipCreatedAt);
 
         rightValuesPanel.setBorder(new EmptyBorder(2, 5, 2, 10));

--- a/src/main/java/com/flipper/views/margins/MarginPanel.java
+++ b/src/main/java/com/flipper/views/margins/MarginPanel.java
@@ -51,13 +51,12 @@ public class MarginPanel extends JPanel {
                     setVisible(false);
                 }
             });
-            ItemComposition itemComp = itemManager.getItemComposition(margin.getItemId());
 
             this.setLayout(new BorderLayout());
             this.setBorder(new EmptyBorder(0, 5, 3, 5));
             container.setLayout(new BorderLayout());
             setBackground(ColorScheme.DARK_GRAY_COLOR);
-            container.add(new ItemHeader(margin.getItemId(), 0, itemComp.getName(), itemManager, false, deleteMarginButton), BorderLayout.NORTH);
+            container.add(new ItemHeader(margin.getItemId(), 0, margin.getItemName(), itemManager, false, deleteMarginButton), BorderLayout.NORTH);
             constructItemInfo();
             JButton convertToFlipButton = new JButton("Convert To Flip");
             convertToFlipButton.addActionListener((ActionEvent event) -> {

--- a/src/main/java/com/flipper/views/margins/MarginPanel.java
+++ b/src/main/java/com/flipper/views/margins/MarginPanel.java
@@ -7,8 +7,7 @@ import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 
-import java.awt.BorderLayout;
-import java.awt.GridLayout;
+import java.awt.*;
 
 import com.flipper.helpers.Numbers;
 import com.flipper.helpers.Timestamps;
@@ -27,7 +26,7 @@ import java.util.function.Consumer;
 public class MarginPanel extends JPanel {
     private Flip margin;
 
-    private final int LABEL_COUNT = 4;
+    private final int LABEL_COUNT = 5;
 
     private JPanel container = new JPanel();
     private JPanel itemInfo = new JPanel(new BorderLayout());
@@ -94,11 +93,13 @@ public class MarginPanel extends JPanel {
 
         JLabel buyAtLabel = newLeftLabel("Buy At:");
         JLabel sellAtLabel = newLeftLabel("Sell At:");
+        JLabel taxLabel = newLeftLabel("Tax:");
         JLabel potentialProfitLabel = newLeftLabel("Profit Per:");
         JLabel dateLabel = newLeftLabel("Date:");
 
         addLeftLabel(buyAtLabel);
         addLeftLabel(sellAtLabel);
+        addLeftLabel(taxLabel);
         addLeftLabel(potentialProfitLabel);
         addLeftLabel(dateLabel);
 
@@ -113,6 +114,14 @@ public class MarginPanel extends JPanel {
         return newRightLabel;
     }
 
+    private JLabel newRightLabel(String value, Color fontColor) {
+        JLabel newRightLabel = new JLabel(value);
+        newRightLabel.setHorizontalAlignment(JLabel.RIGHT);
+        newRightLabel.setForeground(fontColor);
+        newRightLabel.setBorder(new EmptyBorder(0, 0, 2, 0));
+        return newRightLabel;
+    }
+
     private void addRightLabel(JLabel newRightLabel) {
         rightValuesPanel.add(newRightLabel);
     }
@@ -120,20 +129,23 @@ public class MarginPanel extends JPanel {
     private void constructRightLabels() {
         rightValuesPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
 
-        int potentialProfitPer = this.margin.buyPrice - this.margin.sellPrice;
+        int potentialProfitPer = this.margin.buyPrice - this.margin.sellPrice - this.margin.getTax();
 
         String buyAtText = Integer.toString(this.margin.sellPrice);
         String sellAtText = Integer.toString(this.margin.buyPrice);
+        String taxText = Integer.toString(this.margin.getTax());
         String potentialProfitEachText = Integer.toString(potentialProfitPer);
 
         JLabel buyAtLabel = newRightLabel(Numbers.numberWithCommas(buyAtText));
         JLabel sellAtLabel = newRightLabel(Numbers.numberWithCommas(sellAtText));
+        JLabel taxLabel = newRightLabel(Numbers.numberWithCommas(taxText), ColorScheme.PROGRESS_ERROR_COLOR);
         JLabel potentialProfitEachLabel = newRightLabel(Numbers.numberWithCommas(potentialProfitEachText));
         String formattedTimestamp = margin.getCreatedAt() != null ? Timestamps.format(margin.getCreatedAt()) : "--";
         JLabel dateLabel = newRightLabel(formattedTimestamp);
 
         addRightLabel(buyAtLabel);
         addRightLabel(sellAtLabel);
+        addRightLabel(taxLabel);
         addRightLabel(potentialProfitEachLabel);
         addRightLabel(dateLabel);
 

--- a/src/main/java/com/flipper/views/transactions/TransactionPanel.java
+++ b/src/main/java/com/flipper/views/transactions/TransactionPanel.java
@@ -33,8 +33,8 @@ public class TransactionPanel extends JPanel {
 
     private final int LABEL_COUNT = 3;
 
-    private JPanel leftInfoTextPanel = new JPanel(new GridLayout(LABEL_COUNT, 1));
-    private JPanel rightValuesPanel = new JPanel(new GridLayout(LABEL_COUNT, 1));
+    private JPanel leftInfoTextPanel;
+    private JPanel rightValuesPanel;
 
     private Transaction transaction;
     private Supplier<JButton> renderExtraComponentSupplier;
@@ -83,6 +83,17 @@ public class TransactionPanel extends JPanel {
         Consumer<UUID> removeTransactionConsumer,
         boolean isPrompt
     ) {
+        if(transaction.isBuy())
+        {
+            leftInfoTextPanel = new JPanel(new GridLayout(LABEL_COUNT, 1));
+            rightValuesPanel = new JPanel(new GridLayout(LABEL_COUNT, 1));
+        }
+        else
+        {
+            leftInfoTextPanel = new JPanel(new GridLayout(LABEL_COUNT+1, 1));
+            rightValuesPanel = new JPanel(new GridLayout(LABEL_COUNT+1, 1));
+        }
+
         SwingUtilities.invokeLater(() -> {
             this.transaction = transaction;
             setLayout(new BorderLayout());
@@ -179,6 +190,15 @@ public class TransactionPanel extends JPanel {
         JLabel pricePerValue = newRightLabel(pricePerString, ColorScheme.GRAND_EXCHANGE_ALCH);
         addLeftLabel(pricePerLabel);
         addRightLabel(pricePerValue);
+
+        if(!transaction.isBuy())
+        {
+            String taxPerString = Numbers.numberWithCommas(transaction.getTax());
+            JLabel taxPerLabel = newLeftLabel("Tax Per:");
+            JLabel taxPerValue = newRightLabel(taxPerString, ColorScheme.PROGRESS_ERROR_COLOR);
+            addLeftLabel(taxPerLabel);
+            addRightLabel(taxPerValue);
+        }
 
         String quantityValueText = transaction.isFilled() 
             ? quantityString

--- a/src/main/java/com/flipper/views/transactions/TransactionPanel.java
+++ b/src/main/java/com/flipper/views/transactions/TransactionPanel.java
@@ -102,7 +102,6 @@ public class TransactionPanel extends JPanel {
                 }
             });
 
-            ItemComposition itemComp = itemManager.getItemComposition(transaction.getItemId());
             container = new JPanel();
             container.setLayout(new BorderLayout());
             container.setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -110,7 +109,7 @@ public class TransactionPanel extends JPanel {
                 new ItemHeader(
                     transaction.getItemId(),
                     transaction.getPricePer(),
-                    itemComp.getName(),
+                    transaction.getItemName(),
                     itemManager,
                     false,
                     deleteTransactionButton


### PR DESCRIPTION
Adding updates to account for tax. Also refactoring some old code that was causing exceptions due to Runelite updates with 'ItemManager.getItemComposition', such that they must now be called from ClientThread.

Key notes:
*Flips, Alchs, And Margins now lookup their 'itemName' upon loading from persistence files and retrieval from the API.
*Sells tab, Flips tab, Margins tab all include tax information and adjust the total profits.
*Reordered the labels as QoL for including tax